### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/template_parser.py
+++ b/template_parser.py
@@ -56,7 +56,7 @@ def read_template_types(template_type, container_cmd):
                         cmd_output = subprocess.check_output(cmd.split())
                         repl_str = cmd_output.strip()
                         orig_str = "`"+cmd+"`"
-        if orig_str != None and repl_str != None:
+        if orig_str is not None and repl_str is not None:
             filedata = None
             with open(template_path, 'r') as f:
                 filedata = f.read()


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:CyberReboot:vent?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:CyberReboot:vent?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)