### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/core/rmq-es-connector/rmq_es_connector.py
+++ b/core/rmq-es-connector/rmq_es_connector.py
@@ -29,7 +29,7 @@ while wait:
 
 binding_keys = sys.argv[1:]
 if not binding_keys:
-    print >> sys.stderr, "Usage: %s [binding_key]..." % (sys.argv[0],)
+    print >> sys.stderr, "Usage: {0!s} [binding_key]...".format(sys.argv[0])
     sys.exit(1)
 
 for binding_key in binding_keys:
@@ -53,7 +53,7 @@ def callback(ch, method, properties, body):
     try:
         doc = ast.literal_eval(body)
         res = es.index(index=index, doc_type=method.routing_key.split(".")[0], id=method.routing_key+"."+str(uuid.uuid4()), body=doc)
-        print " [x] "+str(datetime.datetime.utcnow())+" UTC %r:%r" % (method.routing_key, body,)
+        print " [x] "+str(datetime.datetime.utcnow())+" UTC {0!r}:{1!r}".format(method.routing_key, body)
     except:
         pass
 

--- a/menu_launcher.py
+++ b/menu_launcher.py
@@ -638,7 +638,7 @@ def runmenu(menu, parent):
     if parent is None:
         lastoption = "Exit"
     else:
-        lastoption = "Return to %s menu" % parent['title']
+        lastoption = "Return to {0!s} menu".format(parent['title'])
 
     optioncount = len(menu['options'])
 
@@ -674,15 +674,15 @@ def runmenu(menu, parent):
                             i += 1
                     else:
                         result = check_output((menu['options'][index]['command']).split())
-                    screen.addstr(5+index,4, "%s - %s" % (menu['options'][index]['title'], result), textstyle)
+                    screen.addstr(5+index,4, "{0!s} - {1!s}".format(menu['options'][index]['title'], result), textstyle)
                 elif menu['options'][index]['type'] == INFO2:
-                    screen.addstr(5+index,4, "%s" % (menu['options'][index]['title']), textstyle)
+                    screen.addstr(5+index,4, "{0!s}".format((menu['options'][index]['title'])), textstyle)
                 else:
-                    screen.addstr(5+index,4, "%d - %s" % (index+1, menu['options'][index]['title']), textstyle)
+                    screen.addstr(5+index,4, "{0:d} - {1!s}".format(index+1, menu['options'][index]['title']), textstyle)
             textstyle = n
             if pos==optioncount:
                 textstyle = h
-            screen.addstr(6+optioncount,4, "%d - %s" % (optioncount+1, lastoption), textstyle)
+            screen.addstr(6+optioncount,4, "{0:d} - {1!s}".format(optioncount+1, lastoption), textstyle)
             screen.refresh()
 
         x = screen.getch()


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:CyberReboot:vent?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:CyberReboot:vent?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)