### PR TITLE
Stopping and starting `All` now starts stopped containers. Closes #92

### DIFF
--- a/template_parser.py
+++ b/template_parser.py
@@ -101,7 +101,9 @@ def read_template_types(template_type, container_cmd, path_dirs):
         if template_type in mode_enabled:
             mode_enabled = mode_enabled[template_type]
         elif template_type in ['active', 'passive'] and 'collectors' in mode_enabled:
-            mode_enabled = mode_enabled['collectors']
+            mode_enabled = [container for container in mode_enabled['collectors'] if container.startswith(template_type+"-")]
+
+        print mode_enabled
         # filters out core_disabled containers from modes_enabled list.
         core_enabled, core_disabled = ast.literal_eval(subprocess.check_output("python2.7 "+info_dir+"get_status.py cenabled -b "+path_dirs.base_dir, shell=True))
 
@@ -109,8 +111,20 @@ def read_template_types(template_type, container_cmd, path_dirs):
             core_disabled = core_disabled[template_type]
         elif template_type in ['active', 'passive'] and 'collectors' in core_disabled:
             core_disabled = core_disabled['collectors']
-        
+
         sections = [container for container in mode_enabled if not container in core_disabled]
+
+        # start enabled containers. If a container is restarted from stopped to running, remove it from 'sections'
+        stopped_containers = subprocess.check_output("docker ps -a --filter 'status=exited' --filter 'name="+template_type+"-' | awk '{print $NF}'", shell=True).split("\n")
+        print stopped_containers
+        restarted_containers = []
+        for sc in stopped_containers:
+            for section in sections:
+                if sc.startswith(section):
+                    os.system("docker start "+sc)
+                    restarted_containers.append(section)
+
+        sections = [section for section in sections if not section in restarted_containers]
 
         # add sections that exist in the template, but are not enabled containers
         config = ConfigParser.RawConfigParser()
@@ -121,6 +135,7 @@ def read_template_types(template_type, container_cmd, path_dirs):
             if s in ["info", "service", "locally-active", "external", "instances", "active-containers", "local-collection"]:
                 sections.append(s)
     except Exception as e:
+        print str(e)
         sections = []
 
     try:
@@ -193,6 +208,7 @@ def read_template_types(template_type, container_cmd, path_dirs):
                         sections.append(tool)
             except Exception as e:
                 pass
+
         # parse through each section of the template file, creating corresponding fields for the JSON file written in execute_template()
         for section in sections:
             host_config_exists = False

--- a/template_parser.py
+++ b/template_parser.py
@@ -103,27 +103,23 @@ def read_template_types(template_type, container_cmd, path_dirs):
         elif template_type in ['active', 'passive'] and 'collectors' in mode_enabled:
             mode_enabled = [container for container in mode_enabled['collectors'] if container.startswith(template_type+"-")]
 
-        print mode_enabled
         # filters out core_disabled containers from modes_enabled list.
         core_enabled, core_disabled = ast.literal_eval(subprocess.check_output("python2.7 "+info_dir+"get_status.py cenabled -b "+path_dirs.base_dir, shell=True))
-
         if template_type in core_disabled:
             core_disabled = core_disabled[template_type]
         elif template_type in ['active', 'passive'] and 'collectors' in core_disabled:
             core_disabled = core_disabled['collectors']
-
         sections = [container for container in mode_enabled if not container in core_disabled]
 
         # start enabled containers. If a container is restarted from stopped to running, remove it from 'sections'
         stopped_containers = subprocess.check_output("docker ps -a --filter 'status=exited' --filter 'name="+template_type+"-' | awk '{print $NF}'", shell=True).split("\n")
-        print stopped_containers
+        stopped_containers = sorted(stopped_containers)
         restarted_containers = []
         for sc in stopped_containers:
             for section in sections:
-                if sc.startswith(section):
+                if section in sc:
                     os.system("docker start "+sc)
                     restarted_containers.append(section)
-
         sections = [section for section in sections if not section in restarted_containers]
 
         # add sections that exist in the template, but are not enabled containers
@@ -135,7 +131,6 @@ def read_template_types(template_type, container_cmd, path_dirs):
             if s in ["info", "service", "locally-active", "external", "instances", "active-containers", "local-collection"]:
                 sections.append(s)
     except Exception as e:
-        print str(e)
         sections = []
 
     try:


### PR DESCRIPTION
Previously:
- Stopped containers are ignored, and all started containers are new (non-core)

Now:
 - Stopped core/collector/visualization containers are restarted.