### PR TITLE
Issue557

### DIFF
--- a/vent/menus/tools.py
+++ b/vent/menus/tools.py
@@ -60,7 +60,7 @@ class ToolForm(npyscreen.ActionForm):
             has_core = {}
             has_non_core = {}
 
-            # find all tools that are in this repo 
+            # find all tools that are in this repo
             # and list them if they are core
             for repo in repos:
                 core_list = []

--- a/vent/menus/tools.py
+++ b/vent/menus/tools.py
@@ -8,6 +8,7 @@ from vent.helpers.logs import Logger
 from vent.helpers.meta import Containers
 from vent.helpers.meta import Images
 
+
 class ToolForm(npyscreen.ActionForm):
     """ Tools form for the Vent CLI """
     def __init__(self, *args, **keywords):
@@ -53,15 +54,14 @@ class ToolForm(npyscreen.ActionForm):
         if response[0]:
             inventory = response[1]
 
-            # TODO refactor this
-            # maybe above message is unnessary now
             repos = inventory['repos']
 
             # dict has repo as key and list of core/non-core tools as values
             has_core = {}
             has_non_core = {}
 
-            # find all tools that are in this repo and list them if they are core
+            # find all tools that are in this repo 
+            # and list them if they are core
             for repo in repos:
                 core_list = []
                 ncore_list = []
@@ -75,7 +75,7 @@ class ToolForm(npyscreen.ActionForm):
 
                     # cross reference repo names
                     if (repo_name[0] == tool_repo_name[0] and
-                        repo_name[1] == tool_repo_name[1]):
+                            repo_name[1] == tool_repo_name[1]):
 
                         # add the tools to their corresponding list
                         if tool in inventory['core']:

--- a/vent/menus/tools.py
+++ b/vent/menus/tools.py
@@ -54,10 +54,10 @@ class ToolForm(npyscreen.ActionForm):
             inventory = response[1]
 
             # TODO refactor this
+            # maybe above message is unnessary now
             repos = inventory['repos']
 
-            # two dictionaries that have lists as values
-            # represent that repo's core/non-core tools
+            # dict has repo as key and list of core/non-core tools as values
             has_core = {}
             has_non_core = {}
 
@@ -83,7 +83,6 @@ class ToolForm(npyscreen.ActionForm):
                         else:
                             ncore_list.append(tool)
 
-                # now add the list as a value for the dictionaries
                 has_core[repo] = core_list
                 has_non_core[repo] = ncore_list
 


### PR DESCRIPTION
Made the create function more generic. Before, it had CYBERREBOOT hard coded in, which may not always be true. 

Also, if a repo has both core and non-core tools in it, the function should be able to separate the two and list the tools accordingly. 

Two things I am unsure about:
1) I don't really know what **self.tools_tc** does, so I just copied it from before the refactor. 
2) I am also unsure how the **i** variable works. It seems like it is there to help keep the formatting of the menu when multiple repos and tools are listed. I hope my refactor still keeps that formatting though I am not 100% sure. 