### PR TITLE
File watch can handle recursive directories now

### DIFF
--- a/vent/api/actions.py
+++ b/vent/api/actions.py
@@ -414,7 +414,8 @@ class Action:
                 options = bmanifest.options(tool)[1]
                 for vals in bmanifest.section(tool)[1]:
                     constraints[vals[0]] = vals[1]
-                backedup_tool = bmanifest.constrained_sections(constraints, options)
+                backedup_tool = bmanifest.constrained_sections(constraints,
+                                                               options)
                 t_info = backedup_tool[tool]
                 if t_info['type'] == 'repository':
                     # for purposes of the add method (only adding a sepcific

--- a/vent/core/file_drop/file_drop.py
+++ b/vent/core/file_drop/file_drop.py
@@ -79,7 +79,7 @@ if __name__ == '__main__':  # pragma: no cover
         args = sys.argv[1:]
 
     observer = Observer()
-    observer.schedule(GZHandler(), path=args[0] if args else '/files')
+    observer.schedule(GZHandler(), path=args[0] if args else '/files', recursive=True)
     observer.start()
 
     try:

--- a/vent/core/file_drop/file_drop.py
+++ b/vent/core/file_drop/file_drop.py
@@ -79,7 +79,8 @@ if __name__ == '__main__':  # pragma: no cover
         args = sys.argv[1:]
 
     observer = Observer()
-    observer.schedule(GZHandler(), path=args[0] if args else '/files', recursive=True)
+    observer.schedule(GZHandler(), path=args[0] if args else '/files',
+                      recursive=True)
     observer.start()
 
     try:

--- a/vent/core/rq_worker/file_watch.py
+++ b/vent/core/rq_worker/file_watch.py
@@ -28,6 +28,7 @@ def file_queue(path, template_path="/vent/"):
             files = '/'
 
         _, path = path.split('_', 1)
+        directory = path.rsplit('/', 1)[0]
         path = path.replace('/files', files, 1)
 
         labels = {'vent-plugin': '', 'file': path}
@@ -54,13 +55,24 @@ def file_queue(path, template_path="/vent/"):
             if config.has_option(section, 'settings'):
                 try:
                     options_dict = json.loads(config.get(section, 'settings'))
-                    for option in options_dict:
-                        if option == 'ext_types':
-                            ext_types = options_dict[option].split(',')
-                            for ext_type in ext_types:
-                                if path.endswith(ext_type):
-                                    images.append(image_name)
-                                    configs[image_name] = {}
+                    process_file = False
+                    # check if this tool should look at files in base dir
+                    if 'process_base' in options_dict:
+                        if (options_dict['process_base'] == 'yes' and
+                                directory == '/files'):
+                            process_file = True
+                    # check if this tool should look at subdirs created by other
+                    # tools' output
+                    if 'process_from_tool' in options_dict:
+                        for tool in options_dict['process_from_tool'].split(','):
+                            if tool.replace(' ', '-') in directory:
+                                process_file = True
+                    if 'ext_types' in options_dict and process_file:
+                        ext_types = options_dict['ext_types'].split(',')
+                        for ext_type in ext_types:
+                            if path.endswith(ext_type):
+                                images.append(image_name)
+                                configs[image_name] = {}
                 except Exception as e:   # pragma: no cover
                     failed_images.add(image_name)
                     status = (False, str(e))

--- a/vent/core/rq_worker/file_watch.py
+++ b/vent/core/rq_worker/file_watch.py
@@ -61,8 +61,8 @@ def file_queue(path, template_path="/vent/"):
                         if (options_dict['process_base'] == 'yes' and
                                 directory == '/files'):
                             process_file = True
-                    # check if this tool should look at subdirs created by other
-                    # tools' output
+                    # check if this tool should look at subdirs created by
+                    # other tools' output
                     if 'process_from_tool' in options_dict:
                         for tool in options_dict['process_from_tool'].split(','):
                             if tool.replace(' ', '-') in directory:

--- a/vent/core/rq_worker/file_watch.py
+++ b/vent/core/rq_worker/file_watch.py
@@ -55,15 +55,16 @@ def file_queue(path, template_path="/vent/"):
             if config.has_option(section, 'settings'):
                 try:
                     options_dict = json.loads(config.get(section, 'settings'))
-                    process_file = False
-                    # check if this tool should look at files in base dir
+                    in_base = directory == '/files'
+                    # process base by default
+                    process_file = True if in_base else False
+                    # check if this tool shouldn't process the base by default
                     if 'process_base' in options_dict:
-                        if (options_dict['process_base'] == 'yes' and
-                                directory == '/files'):
-                            process_file = True
+                        if options_dict['process_base'] == 'no':
+                            process_file = False
                     # check if this tool should look at subdirs created by
                     # other tools' output
-                    if 'process_from_tool' in options_dict:
+                    if 'process_from_tool' in options_dict and not in_base:
                         for tool in options_dict['process_from_tool'].split(','):
                             if tool.replace(' ', '-') in directory:
                                 process_file = True


### PR DESCRIPTION
The way that I have implemented this is to have each plugin tool (in the vent.template) define whether or not they can analyze things in the base directory (aka they get the first look at files), and also any tools they will look at outputs for. Any tool that produces output must create a folder with its name in it (as defined under the info section in the vent.template) in the base directory and then put its outputs into that directory. Then, any tool that is supposed to look at the output of that tool will know to analyze that new subdirectory with files in it that it has created. 