### PR TITLE
Start now takes group ordering into account

### DIFF
--- a/vent/api/plugin_helpers.py
+++ b/vent/api/plugin_helpers.py
@@ -581,7 +581,8 @@ class PluginHelper:
         # start tools in order of group defined in vent.cfg
         for group in cfg_groups:
             # remove from all_groups because already checked out
-            all_groups.remove(group)
+            if group in all_groups:
+                all_groups.remove(group)
             if group in group_orders:
                 for cont_t in sorted(group_orders[group]):
                     if cont_t[1] not in s_conts:


### PR DESCRIPTION
The way I did this is I have start_priority_containers look at a section called [groups] in the vent.cfg for an option called start_order, which lists off the groups in the order in which the user wants them to start, comma separated (image of this below). Do we want to start all containers of a certain group that have a priority over all the others, or just those that have a priority? Right now, those that don't have a priority just get started less in any order in start_remaining_containers.

<img width="286" alt="screen shot 2017-08-03 at 7 47 44 pm" src="https://user-images.githubusercontent.com/26986689/28952243-c660276c-7884-11e7-83ad-ad53df9c174c.png">
