### PR TITLE
Users can no longer re-install a tool that is already installed and write over its information in manifest

### DIFF
--- a/vent/api/actions.py
+++ b/vent/api/actions.py
@@ -33,19 +33,39 @@ class Action:
         self.logger.info("Starting: add")
         status = (True, None)
         try:
-            status = self.plugin.add(repo,
-                                     tools=tools,
-                                     overrides=overrides,
-                                     version=version,
-                                     branch=branch,
-                                     build=build,
-                                     user=user,
-                                     pw=pw,
-                                     groups=groups,
-                                     version_alias=version_alias,
-                                     wild=wild,
-                                     remove_old=remove_old,
-                                     disable_old=disable_old)
+            # remove tools that are already installed from being added
+            i = len(tools) - 1
+            while i >= 0:
+                tool = tools[i]
+                if tool[0].find('@') >= 0:
+                    tool_name = tool[0].split('@')[-1]
+                else:
+                    tool_name = tool[0].rsplit('/', 1)[-1]
+                constraints = {'name': tool_name,
+                               'repo': repo.split('.git')[0]}
+                prev_installed, _ = self.p_helper. \
+                                    constraint_options(constraints, [])
+                # don't reinstall
+                if prev_installed:
+                    tools.remove(tool)
+                i -= 1
+            if tools:
+                status = self.plugin.add(repo,
+                                         tools=tools,
+                                         overrides=overrides,
+                                         version=version,
+                                         branch=branch,
+                                         build=build,
+                                         user=user,
+                                         pw=pw,
+                                         groups=groups,
+                                         version_alias=version_alias,
+                                         wild=wild,
+                                         remove_old=remove_old,
+                                         disable_old=disable_old)
+            else:
+                self.logger.info("no new tools to add, exiting")
+                status = (True, "previously installed")
         except Exception as e:  # pragma: no cover
             self.logger.error("add failed with error: " + str(e))
             status = (False, str(e))

--- a/vent/api/actions.py
+++ b/vent/api/actions.py
@@ -34,22 +34,23 @@ class Action:
         status = (True, None)
         try:
             # remove tools that are already installed from being added
-            i = len(tools) - 1
-            while i >= 0:
-                tool = tools[i]
-                if tool[0].find('@') >= 0:
-                    tool_name = tool[0].split('@')[-1]
-                else:
-                    tool_name = tool[0].rsplit('/', 1)[-1]
-                constraints = {'name': tool_name,
-                               'repo': repo.split('.git')[0]}
-                prev_installed, _ = self.p_helper. \
-                                    constraint_options(constraints, [])
-                # don't reinstall
-                if prev_installed:
-                    tools.remove(tool)
-                i -= 1
-            if tools:
+            if isinstance(tools, list):
+                i = len(tools) - 1
+                while i >= 0:
+                    tool = tools[i]
+                    if tool[0].find('@') >= 0:
+                        tool_name = tool[0].split('@')[-1]
+                    else:
+                        tool_name = tool[0].rsplit('/', 1)[-1]
+                    constraints = {'name': tool_name,
+                                   'repo': repo.split('.git')[0]}
+                    prev_installed, _ = self.p_helper. \
+                                        constraint_options(constraints, [])
+                    # don't reinstall
+                    if prev_installed:
+                        tools.remove(tool)
+                    i -= 1
+            if tools is None or len(tools) > 0:
                 status = self.plugin.add(repo,
                                          tools=tools,
                                          overrides=overrides,

--- a/vent/api/menu_helpers.py
+++ b/vent/api/menu_helpers.py
@@ -59,8 +59,9 @@ class MenuHelper:
                                         constraint_options(constraints, [])
                     if not prev_installed:
                         tools.append((match[0], ''))
-                # only add stuff not already installed
-                if tools:
+                # only add stuff not already installed or repo specification
+                if ((tools) or
+                        (isinstance(matches, list) and len(matches) == 0)):
                     status = self.plugin.add(core_repo,
                                              tools=tools,
                                              branch=branch,

--- a/vent/api/menu_helpers.py
+++ b/vent/api/menu_helpers.py
@@ -33,7 +33,7 @@ class MenuHelper:
             if action in ["install", "build"]:
                 tools = []
                 core_repo = 'https://github.com/cyberreboot/vent'
-                resp = self.p_helper.apply_path('https://github.com/cyberreboot/vent')
+                resp = self.p_helper.apply_path(core_repo)
 
                 if resp[0]:
                     cwd = resp[1]
@@ -61,7 +61,7 @@ class MenuHelper:
                         tools.append((match[0], ''))
                 # only add stuff not already installed
                 if tools:
-                    status = self.plugin.add('https://github.com/cyberreboot/vent',
+                    status = self.plugin.add(core_repo,
                                              tools=tools,
                                              branch=branch,
                                              build=False, core=True)

--- a/vent/api/menu_helpers.py
+++ b/vent/api/menu_helpers.py
@@ -66,27 +66,27 @@ class MenuHelper:
                                              branch=branch,
                                              build=False, core=True)
                     self.logger.info("status of plugin add: " + str(status))
-                    plugin_c = Template(template=self.plugin.manifest)
-                    sections = plugin_c.sections()
-                    for tool in core['normal']:
-                        for section in sections[1]:
-                            name = plugin_c.option(section, "name")
-                            orig_branch = plugin_c.option(section, "branch")
-                            namespace = plugin_c.option(section, "namespace")
-                            version = plugin_c.option(section, "version")
-                            if (name[1] == tool and
-                               orig_branch[1] == branch and
-                               namespace[1] == "cyberreboot/vent" and
-                               version[1] == "HEAD"):
-                                plugin_c.set_option(section,
-                                                    "image_name",
-                                                    "cyberreboot/vent-" +
-                                                    tool.replace('_', '-') + ":" +
-                                                    branch)
-                    plugin_c.write_config()
                 else:
                     self.logger.info("no new tools to install")
                     status = (True, "previously installed")
+                plugin_c = Template(template=self.plugin.manifest)
+                sections = plugin_c.sections()
+                for tool in core['normal']:
+                    for section in sections[1]:
+                        name = plugin_c.option(section, "name")
+                        orig_branch = plugin_c.option(section, "branch")
+                        namespace = plugin_c.option(section, "namespace")
+                        version = plugin_c.option(section, "version")
+                        if (name[1] == tool and
+                           orig_branch[1] == branch and
+                           namespace[1] == "cyberreboot/vent" and
+                           version[1] == "HEAD"):
+                            plugin_c.set_option(section,
+                                                "image_name",
+                                                "cyberreboot/vent-" +
+                                                tool.replace('_', '-') + ":" +
+                                                branch)
+                plugin_c.write_config()
                 chdir(cwd)
             if action == "build":
                 plugin_c = Template(template=self.plugin.manifest)

--- a/vent/api/plugin_helpers.py
+++ b/vent/api/plugin_helpers.py
@@ -146,8 +146,13 @@ class PluginHelper:
             chdir(status[1])
             status = (True, status[1])
         except Exception as e:  # pragma: no cover
-            self.logger.error("clone failed with error: " + str(e))
-            status = (False, str(e))
+            e_str = str(e)
+            # scrub username and password from error message
+            if e_str.find('@') >= 0:
+                e_str = e_str[:e_str.find('//') + 2] + \
+                        e_str[e_str.find('@') + 1:]
+            self.logger.error("clone failed with error: " + e_str)
+            status = (False, e_str)
         self.logger.info("Status of clone: " + str(status))
         self.logger.info("Finished: clone")
         return status

--- a/vent/menus/choose_tools.py
+++ b/vent/menus/choose_tools.py
@@ -30,8 +30,12 @@ class ChooseToolsForm(npyscreen.ActionForm):
         self.add(npyscreen.TitleText,
                  name='Select which tools to add from each branch selected:',
                  editable=False)
+        self.add(npyscreen.Textfield,
+                 value='NOTE tools you have already installed will be ignored',
+                 color='STANDOUT',
+                 editable=False)
 
-        i = 4
+        i = 6
         for branch in self.parentApp.repo_value['versions']:
             self.tools_tc[branch] = {}
             self.add(npyscreen.TitleText,

--- a/vent/menus/main.py
+++ b/vent/menus/main.py
@@ -205,7 +205,8 @@ class MainForm(npyscreen.FormBaseNewWithMenus):
                          kwargs={"action": "install"})
             popup(original_images, "images", thr,
                   'Please wait, installing core containers...')
-            notify_confirm("Done installing core containers.",
+            notify_confirm("Done installing core containers (any"
+                           " already installed tools untouched).",
                            title='Installed core containers')
         return
 


### PR DESCRIPTION
If users want to update a tool, they can simply use the update function. Trying to re-add a tool that is already installed will write over information in manifest.