### PR TITLE
Get the default device IP address

### DIFF
--- a/dev/vendor/tinycore-python2/Dockerfile
+++ b/dev/vendor/tinycore-python2/Dockerfile
@@ -94,7 +94,7 @@ RUN tce-load -wic \
     && rm -rf /tmp/tce/optional/* \
     && curl -SL 'https://bootstrap.pypa.io/get-pip.py' | sudo python2 \
     && sudo pip install --no-cache-dir --upgrade pip==$PYTHON_PIP_VERSION \
-    && sudo pip install --no-cache-dir docker netifaces npyscreen \
+    && sudo pip install --no-cache-dir docker npyscreen \
     && sudo pip install --no-cache-dir git+git://github.com/cyberreboot/vent.git@master \
     && sudo pip uninstall -y pip \
     && sudo find /usr/local \( -type f -a -name '*.pyc' -o -name '*.pyo' \) -exec rm -rf '{}' + \

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,5 @@
 docker
 elasticsearch
-netifaces
 npyscreen
 paste
 pika

--- a/vent/api/plugin_helpers.py
+++ b/vent/api/plugin_helpers.py
@@ -654,18 +654,22 @@ class PluginHelper:
                         host = result[1]
                     else:
                         # now just requires ip, ifconfig
-                        route = check_output(('ip', 'route')).split('\n')
-                        default = ''
-                        # grab the default network device.
-                        for device in route:
-                            if 'default' in device:
-                                default = device.split()[4]
-                                break
+                        try:
+                            route = check_output(('ip', 'route')).split('\n')
+                            default = ''
+                            # grab the default network device.
+                            for device in route:
+                                if 'default' in device:
+                                    default = device.split()[4]
+                                    break
 
-                        # grab the IP address for the default device
-                        ip_addr = check_output(('ifconfig', default))
-                        ip_addr = ip_addr.split('\n')[1].split()[1]
-                        host = ip_addr
+                            # grab the IP address for the default device
+                            ip_addr = check_output(('ifconfig', default))
+                            ip_addr = ip_addr.split('\n')[1].split()[1]
+                            host = ip_addr
+                        except Exception as e:  # pragma no cover
+                            self.logger.error('failed to grab ip. Ensure that \
+                                              ip and ifconfig are installed')
                     nd_url = 'http://' + host + ':' + port + '/v1.0/docker/cli'
                     params = {'vol': 'nvidia_driver'}
 

--- a/vent/core/rq_worker/Dockerfile
+++ b/vent/core/rq_worker/Dockerfile
@@ -3,13 +3,9 @@ MAINTAINER Charlie Lewis <clewis@iqt.org>
 
 RUN apk add --update \
     docker \
-    gcc \
     git \
     libmagic \
-    linux-headers \
-    musl-dev \
     python \
-    python-dev \
     py2-pip \
     && rm -rf /var/cache/apk/*
 

--- a/vent/core/rq_worker/requirements.txt
+++ b/vent/core/rq_worker/requirements.txt
@@ -1,4 +1,3 @@
 docker
-netifaces
 python-magic
 rq==0.8.0

--- a/vent/core/rq_worker/watch.py
+++ b/vent/core/rq_worker/watch.py
@@ -128,6 +128,7 @@ def file_queue(path, template_path="/vent/"):
 
     from redis import Redis
     from rq import Queue
+    from subprocess import check_output, Popen, PIPE
     from string import punctuation
 
     status = (True, None)
@@ -289,12 +290,15 @@ def file_queue(path, template_path="/vent/"):
                                 host = vent_config.get('nvidia-docker-plugin', 'host')
                             else:
                                 # grab the default gateway
-                                route = Popen(('/sbin/ip', 'route'),
-                                              stdout=PIPE)
-                                h = check_output(('awk', '/default/ {print$3}'),
-                                                 stdin=route.stdout)
-                                route.wait()
-                                host = h.strip()
+                                try:
+                                    route = Popen(('/sbin/ip', 'route'),
+                                                  stdout=PIPE)
+                                    h = check_output(('awk', '/default/ {print$3}'),
+                                                     stdin=route.stdout)
+                                    route.wait()
+                                    host = h.strip()
+                                except Exception as e:  # pragma no cover
+                                    pass
                             nd_url = 'http://' + host + ':' + port + '/v1.0/docker/cli'
                             params = {'vol': 'nvidia_driver'}
                             try:

--- a/vent/core/rq_worker/watch.py
+++ b/vent/core/rq_worker/watch.py
@@ -118,7 +118,6 @@ def file_queue(path, template_path="/vent/"):
     Processes files that have been added from the rq-worker, starts plugins
     that match the mime type for the new file.
     """
-    import commands
     import ConfigParser
     import ast
     import docker

--- a/vent/helpers/meta.py
+++ b/vent/helpers/meta.py
@@ -172,24 +172,23 @@ def GpuUsage(**kargs):
     result = template.option('nvidia-docker-plugin', 'host')
     if result[0]:
         host = result[1]
-    # TODO ignoring this option for now
-    # else:
-    #    try:
-    #        # now just requires ip, ifconfig
-    #        route = check_output(('ip', 'route')).split('\n')
-    #        default = ''
-    #        # grab the default network device.
-    #        for device in route:
-    #            if 'default' in device:
-    #                default = device.split()[4]
-    #                break
-    #
-    #        # grab the IP address for the default device
-    #        ip_addr = check_output(('ifconfig', default))
-    #        ip_addr = ip_addr.split('\n')[1].split()[1]
-    #        host = ip_addr
-    #    except Exception as e:  # pragma: no cover
-    #        pass
+    else:
+        try:
+            # now just requires ip, ifconfig
+            route = check_output(('ip', 'route')).split('\n')
+            default = ''
+            # grab the default network device.
+            for device in route:
+                if 'default' in device:
+                    default = device.split()[4]
+                    break
+
+            # grab the IP address for the default device
+            ip_addr = check_output(('ifconfig', default))
+            ip_addr = ip_addr.split('\n')[1].split()[1]
+            host = ip_addr
+        except Exception as e:  # pragma: no cover
+            pass
 
     # have to get the info separately to determine how much memory is availabe
     nd_url = 'http://' + host + ':' + port + '/v1.0/gpu/info/json'

--- a/vent/helpers/meta.py
+++ b/vent/helpers/meta.py
@@ -174,16 +174,22 @@ def GpuUsage(**kargs):
         host = result[1]
     # TODO ignoring this option for now
     # else:
-    #     try:
-    #         # get the default device using netifaces
-    #         # external library
-    #         d_device = netifaces.gateways()
-    #         d_device = d_device['default'][netifaces.AF_INET]
-    #         host = netifaces.ifaddresses(d_device[1])
-    #         host = host[netifaces.AF_INET]
-    #         host = host[0]['addr']
-    #     except Exception as e:  # pragma: no cover
-    #         pass
+    #    try:
+    #        # now just requires ip, ifconfig
+    #        route = check_output(('ip', 'route')).split('\n')
+    #        default = ''
+    #        # grab the default network device.
+    #        for device in route:
+    #            if 'default' in device:
+    #                default = device.split()[4]
+    #                break
+    #
+    #        # grab the IP address for the default device
+    #        ip_addr = check_output(('ifconfig', default))
+    #        ip_addr = ip_addr.split('\n')[1].split()[1]
+    #        host = ip_addr
+    #    except Exception as e:  # pragma: no cover
+    #        pass
 
     # have to get the info separately to determine how much memory is availabe
     nd_url = 'http://' + host + ':' + port + '/v1.0/gpu/info/json'


### PR DESCRIPTION
rq_worker now returns the default gateway
removed netifaces because it was crazy dependent on other packages
ip of default device found using good old subprocess library