### PR TITLE
Ncontrol list operations

### DIFF
--- a/vent/core/network_tap/ncontrol/rest/delete.py
+++ b/vent/core/network_tap/ncontrol/rest/delete.py
@@ -36,19 +36,12 @@ class DeleteR:
         except Exception as e:  # pragma: no cover
             return (False, 'unable to connect to docker because: ' + str(e))
 
-        # if user gives a list of id, delete them all
-        if isinstance(payload['id'], list):
-            try:
-                for container_id in payload['id']:
-                    c.containers.get(container_id).remove()
-            except Exception as e:  # pragma: no cover
-                return (False, 'unable to delete list of containers because: '
-                        + str(e))
-        # if user gives just one id, delete it
-        else:
-            try:
-                c.containers.get(payload['id']).remove()
-            except Exception as e:  # pragma: no cover
-                return (False, 'unable to delete container because: ' + str(e))
+        # delete containers chosen from CLI
+        try:
+            for container_id in payload['id']:
+                c.containers.get(container_id).remove()
+        except Exception as e:  # pragma: no cover
+            return (False, 'unable to delete containers because: '
+                    + str(e))
 
         return (True, 'container successfully deleted: ' + str(payload['id']))

--- a/vent/core/network_tap/ncontrol/rest/start.py
+++ b/vent/core/network_tap/ncontrol/rest/start.py
@@ -36,20 +36,12 @@ class StartR:
         except Exception as e:  # pragma: no cover
             return (False, 'unable to connect to docker because: ' + str(e))
 
-        # if user gives a list of id, start them all
-        if isinstance(payload['id'], list):
-            try:
-                for container_id in payload['id']:
-                    c.containers.get(container_id).start()
-            except Exception as e:  # pragma: no cover
-                return (False, 'unable to start list of containers because: ' +
-                        str(e))
-
-        # if user gives just one id, start it
-        else:
-            try:
-                c.containers.get(payload['id']).start()
-            except Exception as e:  # pragma: no cover
-                return (False, 'unable to start container because: ' + str(e))
+        # start containers chosen from CLI
+        try:
+            for container_id in payload['id']:
+                c.containers.get(container_id).start()
+        except Exception as e:  # pragma: no cover
+            return (False, 'unable to start list of containers because: ' +
+                    str(e))
 
         return (True, 'container successfully started: ' + str(payload['id']))

--- a/vent/core/network_tap/ncontrol/rest/stop.py
+++ b/vent/core/network_tap/ncontrol/rest/stop.py
@@ -36,20 +36,13 @@ class StopR:
         except Exception as e:  # pragma: no cover
             return (False, 'unable to connect to docker because: ' + str(e))
 
-        # if user gives a list of id, delete them all
-        if isinstance(payload['id'], list):
-            try:
-                for container_id in payload['id']:
-                    c.containers.get(container_id).stop()
-            except Exception as e:  # pragma: no cover
-                return (False, 'unable to stop list of containers because: ' +
-                        str(e))
-
-        # if user gives just one id, delete it
-        else:
-            try:
-                c.containers.get(payload['id']).stop()
-            except Exception as e:  # pragma: no cover
-                return (False, 'unable to stop container because: ' + str(e))
+        # stop containers chosen from CLI
+        try:
+            for container_id in payload['id']:
+                c.containers.get(container_id).stop()
+        except Exception as e:  # pragma: no cover
+            return(False, payload)
+            #  return (False, 'unable to stop list of containers because: ' +
+            #          str(e))
 
         return (True, 'container successfully stopped: ' + str(payload['id']))

--- a/vent/core/network_tap/ncontrol/rest/stop.py
+++ b/vent/core/network_tap/ncontrol/rest/stop.py
@@ -41,8 +41,7 @@ class StopR:
             for container_id in payload['id']:
                 c.containers.get(container_id).stop()
         except Exception as e:  # pragma: no cover
-            return(False, payload)
-            #  return (False, 'unable to stop list of containers because: ' +
-            #          str(e))
+            return (False, 'unable to stop list of containers because: ' +
+                    str(e))
 
         return (True, 'container successfully stopped: ' + str(payload['id']))

--- a/vent/menus/ntap.py
+++ b/vent/menus/ntap.py
@@ -212,7 +212,8 @@ class ActionNTap(npyscreen.ActionForm):
 
         # format the data into something ncontrol likes
         else:
-            payload = {'id': list(x['id'] for x in self.ms.values)}
+            payload = {'id': list(x['id'] for x in
+                       self.ms.get_selected_objects())}
 
         # grab the url that network-tap is listening to
         try:

--- a/vent/menus/ntap.py
+++ b/vent/menus/ntap.py
@@ -212,7 +212,7 @@ class ActionNTap(npyscreen.ActionForm):
 
         # format the data into something ncontrol likes
         else:
-            payload = {'id': x['id'] for x in self.ms.values}
+            payload = {'id': list(x['id'] for x in self.ms.values)}
 
         # grab the url that network-tap is listening to
         try:


### PR DESCRIPTION
#847

user selection is not split between choosing 1 and having a list. always treated as a list. cleaned up the code a lot. 

Now correctly uses `get_selected_objects` function from `npyscreen` to correctly grab user selected stuff.