### PR TITLE
added vent label to gonet so it gets deleted with factory reset

### DIFF
--- a/vent/extras/gonet/Dockerfile
+++ b/vent/extras/gonet/Dockerfile
@@ -5,8 +5,12 @@ COPY main.go /app/main.go
 WORKDIR /app
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o gonet .
 
+LABEL vent=""
+
 # final stage
 FROM scratch
 MAINTAINER Charlie Lewis <clewis@iqt.org>
 COPY --from=builder /app/gonet /gonet
 CMD ["/gonet"]
+
+LABEL vent=""

--- a/vent/extras/gonet/Dockerfile
+++ b/vent/extras/gonet/Dockerfile
@@ -5,8 +5,6 @@ COPY main.go /app/main.go
 WORKDIR /app
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o gonet .
 
-LABEL vent=""
-
 # final stage
 FROM scratch
 MAINTAINER Charlie Lewis <clewis@iqt.org>


### PR DESCRIPTION
Is it necessary to have the label in both places? I'm assuming 2 images are created for `gonet`

#850 