### PR TITLE
Remove deprecated MAINTAINER from /vent/core/network_tap/Dockerfile a…

### DIFF
--- a/vent/core/network_tap/Dockerfile
+++ b/vent/core/network_tap/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.6
-MAINTAINER Charlie Lewis <clewis@iqt.org>
+LABEL maintainer="Charlie Lewis <clewis@iqt.org>"
 
 RUN apk add --update \
     python \


### PR DESCRIPTION
fixes #950
Set a label corresponding to the MAINTAINER field in /vent/core/network_tap/Dockerfile