### PR TITLE
syslog can't be bound to 127.0.0.1 for docker logger

### DIFF
--- a/vent/core/syslog/syslog-ng.conf
+++ b/vent/core/syslog/syslog-ng.conf
@@ -9,11 +9,11 @@ options {
 };
 
 source s_net {
-    tcp(ip(127.0.0.1)
+    tcp(ip(0.0.0.0)
         log-iw-size(50000)
         port(514)
         max-connections(50));
-    udp(ip(127.0.0.1)
+    udp(ip(0.0.0.0)
         port(514));
     unix-stream("/var/run/syslog-ng/syslog-ng.sock" max-connections(50));
 };

--- a/vent/core/syslog/vent.template
+++ b/vent/core/syslog/vent.template
@@ -12,5 +12,5 @@ priority = 2,1,2
 [docker]
 environment = ["VENT_HOST=`hostname`"]
 volumes = {'/var/log/vent': {'bind': '/var/log/syslog-ng', 'mode': 'rw'}}
-ports = {'514/tcp': ('127.0.0.1', 514)}
+ports = {'514/tcp': ('0.0.0.0', 514)}
 links = {"RabbitMQ":"rabbitmq"}


### PR DESCRIPTION
- [ ] This patch includes any updated documentation of the proposed changes
- [ ] This patch includes tests that verify the proposed changes work as expected
