### PR TITLE
Handle case where volumes is a list

### DIFF
--- a/vent/api/plugin_helpers.py
+++ b/vent/api/plugin_helpers.py
@@ -756,9 +756,15 @@ class PluginHelper:
                             elif option.startswith('--volume='):
                                 vol = option.split('=', 1)[1].split(':')
                                 if 'volumes' in tool_d[container]:
-                                    # !! TODO handle if volumes is a list
-                                    tool_d[container]['volumes'][vol[0]] = {'bind': vol[1],
-                                                                            'mode': vol[2]}
+                                    if isinstance(tool_d[container]['volumes'], list):
+                                        if len(vol) == 2:
+                                            c_vol = vol[0] + ":" + vol[1] + ":rw"
+                                        else:
+                                            c_vol = vol[0] + ":" + vol[1] + ":" + vol[2]
+                                        tool_d[container]['volumes'].append(c_vol)
+                                    else: # Dictionary
+                                        tool_d[container]['volumes'][vol[0]] = {'bind': vol[1],
+                                                                                'mode': vol[2]}
                                 else:
                                     tool_d[container]['volumes'] = {vol[0]:
                                                                     {'bind': vol[1],


### PR DESCRIPTION
From Issue #896 
Checks if volumes is a list and, if so, handles accordingly.  The details in the above issue imply that the third part may be missing (in which case it default to rw) - I've added support for such an eventuality.

- [x] This patch includes any updated documentation of the proposed changes
Specifically - Im not aware of any documentation changes I need to make.

- [ ] This patch includes tests that verify the proposed changes work as expected
I'm not sure how to add a relevant test for this, since it's pretty well embedded within `start_containers`.  Any thoughts \ recommendations?