### PR TITLE
Cut over again to tracecapd, and add a test for capture functionality and payload stripping

### DIFF
--- a/vent/extras/network_tap/ncapture/Dockerfile
+++ b/vent/extras/network_tap/ncapture/Dockerfile
@@ -11,6 +11,7 @@ RUN apk add --update \
     bash \
     bison \
     build-base \
+    coreutils \
     flex \
     gcc \
     git \
@@ -62,7 +63,11 @@ RUN apk add --update \
     gcc \
     git \
     linux-headers \
-    musl-dev
+    musl-dev \
+    && apk add \
+    libstdc++ \
+    libgcc
+
 
 VOLUME /tmp
 WORKDIR /tmp

--- a/vent/extras/network_tap/ncapture/run.sh
+++ b/vent/extras/network_tap/ncapture/run.sh
@@ -36,6 +36,7 @@ run_tracecapd() {
     local dwconf=${CAPTMP}/dw.yaml
     local ppconf=${CAPTMP}/pp.yaml
 
+    # See https://github.com/wanduow/libwdcap for processing options.
     echo -e "format: pcapfile\nnamingscheme: ${name}\ncompressmethod: none\nrotationperiod: day\n" > $dwconf
     echo -e "anon: none\nchecksum: none\npayload: 4\ndnspayload: 12\n" > $ppconf
     $(timeout -k2 ${interval}s tracecapd -t 1 -c $dwconf -p $ppconf -s int:$nic -f "$filter")

--- a/vent/extras/network_tap/ncapture/test_ncapture.sh
+++ b/vent/extras/network_tap/ncapture/test_ncapture.sh
@@ -23,7 +23,7 @@ if [ ! -s $TMPDIR/greater.txt ] ; then
   echo "FAIL: no packets with original size $SIZE"
   exit 1
 fi
-CAPLEN=$(capinfos -l $TMPDIR/*cap|grep inferred|grep -o -E '[0-9]+')
+CAPLEN=$(capinfos -l $TMPDIR/*cap|grep -E 'Packet size limit:\s+inferred: [0-9]+ bytes'|grep -o -E '[0-9]+')
 if [ "$CAPLEN" == "" ] ; then
   echo "FAIL: capture length not limited"
   exit 1

--- a/vent/extras/network_tap/ncapture/test_ncapture.sh
+++ b/vent/extras/network_tap/ncapture/test_ncapture.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# smoke test for ncapture worker
+# requires tcpdump and tshark to be installed.
+
+NIC=lo
+IP=127.0.0.1
+SIZE=1000
+MAXCAPLEN=50
+
+TMPDIR=$(mktemp -d)
+
+docker build -f Dockerfile . -t cyberreboot/vent-ncapture
+echo starting ncapture
+docker run --privileged --net=host --cap-add=NET_ADMIN -v $TMPDIR:/files -t cyberreboot/vent-ncapture /tmp/run.sh $NIC 15 test 1 "host $IP and icmp" || exit 1 &
+echo waiting for pcap
+while [ "$(find $TMPDIR -prune -empty)" ] ; do
+  ping -q -n -i 0.1 -s $SIZE -c 10 $IP > /dev/null
+  echo -n .
+done
+tcpdump -n -r $TMPDIR/*pcap greater $SIZE > $TMPDIR/greater.txt || exit 1
+if [ ! -s $TMPDIR/greater.txt ] ; then
+  echo "FAIL: no packets with original size $SIZE"
+  exit 1
+fi
+CAPLEN=$(capinfos -l $TMPDIR/*cap|grep inferred|grep -o -E '[0-9]+')
+if [ "$CAPLEN" == "" ] ; then
+  echo "FAIL: capture length not limited"
+  exit 1
+fi
+if [ "$CAPLEN" -gt $MAXCAPLEN ] ; then
+  echo "FAIL: capture length $CAPLEN over limit (payload not stripped?)"
+  exit 1
+fi
+echo ok
+
+rm -rf $TMPDIR


### PR DESCRIPTION
Confirmed that the test fails on current tcpdump (payload not stripped).
