### PR TITLE
Support reading packets from non-interfaces and remove obsolete tcpdump.

### DIFF
--- a/vent/extras/network_tap/ncapture/Dockerfile
+++ b/vent/extras/network_tap/ncapture/Dockerfile
@@ -5,6 +5,7 @@ LABEL maintainer="Charlie Lewis <clewis@iqt.org>" \
       vent.groups="collection,hidden,network,network_tap_child"
 
 ENV BUILDDEPS="autoconf automake bison build-base flex gcc git libtool libpcap-dev libpcap linux-headers musl-dev python3-dev yaml-dev"
+WORKDIR /tmp
 
 # TODO: libwdcap currently requires openssl 1.0.2
 RUN apk add --update $BUILDDEPS \
@@ -44,9 +45,7 @@ RUN apk add --update $BUILDDEPS \
     libpcap \
     yaml
 
-
 VOLUME /tmp
-WORKDIR /tmp
 COPY . /tmp
 
 RUN pip3 install --no-cache-dir -r requirements.txt

--- a/vent/extras/network_tap/ncapture/Dockerfile
+++ b/vent/extras/network_tap/ncapture/Dockerfile
@@ -3,30 +3,17 @@ LABEL maintainer="Charlie Lewis <clewis@iqt.org>" \
       vent="" \
       vent.name="ncapture" \
       vent.groups="collection,hidden,network,network_tap_child"
-# TODO: remove custom libcap/tcpdump when cut over to tracepcapd; tracepcapd is built first before tcpdump.
+
+ENV BUILDDEPS="autoconf automake bison build-base flex gcc git libtool libpcap-dev libpcap linux-headers musl-dev python3-dev yaml-dev"
+
 # TODO: libwdcap currently requires openssl 1.0.2
-RUN apk add --update \
-    autoconf \
-    automake \
+RUN apk add --update $BUILDDEPS \
     bash \
-    bison \
-    build-base \
     coreutils \
-    flex \
-    gcc \
-    git \
-    libtool \
-    libpcap-dev \
-    linux-headers \
-    musl-dev \
     python3 \
-    python3-dev \
-    yaml-dev \
     && rm -rf /var/cache/apk/* \
     && mkdir /src \
     && cd /src \
-    && git clone https://github.com/the-tcpdump-group/libpcap.git \
-    && git clone https://github.com/cglewis/tcpdump.git \
     && git clone https://github.com/wanduow/wandio.git \
     && git clone https://github.com/LibtraceTeam/libtrace.git \
     && git clone https://github.com/openssl/openssl -b OpenSSL_1_0_2s \
@@ -49,26 +36,13 @@ RUN apk add --update \
     && cd examples \
     && g++ -fpermissive -o tracecapd tracecapd.c -L/usr/local/lib -Wl,-Bstatic -ltrace -lwdcap -Wl,-Bdynamic -lpcap -lssl -lcrypto -lwandio -lyaml \
     && cp tracecapd /usr/local/bin \
-    && apk del libpcap-dev libpcap \
-    && cd /src/libpcap \
-    && ./configure \
-    && make && make install \
-    && cd /src/tcpdump \
-    && git fetch origin && git checkout send-upstream \
-    && ./configure \
-    && make && make install \
     && rm -rf /src \
-    && apk del \
-    bison \
-    build-base \
-    flex \
-    gcc \
-    git \
-    linux-headers \
-    musl-dev \
+    && apk del $BUILDDEPS \
     && apk add \
     libstdc++ \
-    libgcc
+    libgcc \
+    libpcap \
+    yaml
 
 
 VOLUME /tmp

--- a/vent/extras/network_tap/ncapture/run.sh
+++ b/vent/extras/network_tap/ncapture/run.sh
@@ -19,14 +19,6 @@ make_pcap_name() {
     echo trace_${id}_${dt}.pcap
 }
 
-run_tcpdump() {
-    local nic=$1
-    local name=$2
-    local interval=$3
-    local filter=$4
-    $(timeout -k2 ${interval}s tcpdump -ni $nic --no-tcpudp-payload -w $name $filter)
-}
-
 run_tracecapd() {
     local nic=$1
     local name=$2
@@ -49,7 +41,6 @@ run_capture() {
     local filter=$4
 
     local name=$(make_pcap_name $id)
-    # run_tcpdump $nic $name $interval "$filter"
     run_tracecapd $nic $name $interval "$filter"
     mv $name /files/;
     python3 send_message.py $name;

--- a/vent/extras/network_tap/ncapture/test_ncapture.sh
+++ b/vent/extras/network_tap/ncapture/test_ncapture.sh
@@ -3,7 +3,7 @@
 # smoke test for ncapture worker
 # requires tcpdump and tshark to be installed.
 
-NIC=lo
+URI=lo
 IP=127.0.0.1
 SIZE=1000
 MAXCAPLEN=50
@@ -12,7 +12,7 @@ TMPDIR=$(mktemp -d)
 
 docker build -f Dockerfile . -t cyberreboot/vent-ncapture
 echo starting ncapture
-docker run --privileged --net=host --cap-add=NET_ADMIN -v $TMPDIR:/files -t cyberreboot/vent-ncapture /tmp/run.sh $NIC 15 test 1 "host $IP and icmp" || exit 1 &
+docker run --privileged --net=host --cap-add=NET_ADMIN -v $TMPDIR:/files -t cyberreboot/vent-ncapture /tmp/run.sh $URI 15 test 1 "host $IP and icmp" || exit 1 &
 echo waiting for pcap
 while [ "$(find $TMPDIR -prune -empty)" ] ; do
   ping -q -n -i 0.1 -s $SIZE -c 10 $IP > /dev/null


### PR DESCRIPTION
Allow run.sh to take a libtrace source URI rather than just an interface to read packets from.

You can supply just an interface name by default, or use one of the other supported URIs (https://wand.net.nz/trac/libtrace/wiki/SupportedTraceFormats) - e.g. pcapfile:/a/file.cap