### PR TITLE
Add flags for configurable anonymization options (and potential breaking change for output dir)

### DIFF
--- a/vent/extras/network_tap/ncapture/test_ncapture.sh
+++ b/vent/extras/network_tap/ncapture/test_ncapture.sh
@@ -12,7 +12,7 @@ TMPDIR=$(mktemp -d)
 
 docker build -f Dockerfile . -t cyberreboot/vent-ncapture
 echo starting ncapture
-docker run --privileged --net=host --cap-add=NET_ADMIN -v $TMPDIR:/files -t cyberreboot/vent-ncapture /tmp/run.sh $URI 15 test 1 "host $IP and icmp" || exit 1 &
+docker run --privileged --net=host --cap-add=NET_ADMIN -v $TMPDIR:/files -t cyberreboot/vent-ncapture /tmp/run.sh $URI 15 test 1 "host $IP and icmp" -d 12 -s 4 -a none -c none -o /files/ || exit 1 &
 echo waiting for pcap
 while [ "$(find $TMPDIR -prune -empty)" ] ; do
   ping -q -n -i 0.1 -s $SIZE -c 10 $IP > /dev/null


### PR DESCRIPTION
Change optional non-getopts 6th argument for output dir, to -o getops style.
This is a change in API - users that want to specify output dir will have to switch to -o.

